### PR TITLE
QA: details block

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Medicare For All</title>
   </head>
   <body>
     <noscript>

--- a/src/components/DetailBlock/DetailBlock.scss
+++ b/src/components/DetailBlock/DetailBlock.scss
@@ -33,7 +33,7 @@
   &__text2-container {
     border: spacing(0.2) solid color('gray');
     @media ($medium-up) {
-      margin-top: spacing(60);
+      margin-top: spacing(26);
       min-width: spacing(70);
     }
   }

--- a/src/components/DetailBlock/DetailBlock.scss
+++ b/src/components/DetailBlock/DetailBlock.scss
@@ -37,4 +37,12 @@
       min-width: spacing(70);
     }
   }
+
+  &__logo {
+    display: block;
+
+    @media ($medium-up) {
+      display: none;
+    }
+  }
 }

--- a/src/components/DetailBlock/index.js
+++ b/src/components/DetailBlock/index.js
@@ -58,7 +58,7 @@ class DetailBlock extends Component {
           <img className={cx(styles['DetailBlock__image4'], 'col-12 md:col-5 fit-contain shadow-light my1 md:mx2')} src='/assets/image-shirt-detail-4.jpg' alt='shirt detail' />
         </div>
         <div className={cx(styles['DetailBlock__logo'], 'w100')}>
-          <img className='col-12 my4' src='/assets/sanctu-compu-logo.svg' alt='medicare' />
+          <img className='col-12 my4' src='/assets/sanctu-compu-logo.svg' alt='Sanctuary Computer Logo' />
         </div>
       </div>
     );

--- a/src/components/DetailBlock/index.js
+++ b/src/components/DetailBlock/index.js
@@ -57,6 +57,9 @@ class DetailBlock extends Component {
           </div>
           <img className={cx(styles['DetailBlock__image4'], 'col-12 md:col-5 fit-contain shadow-light my1 md:mx2')} src='/assets/image-shirt-detail-4.jpg' alt='shirt detail' />
         </div>
+        <div className={cx(styles['DetailBlock__logo'], 'w100')}>
+          <img className='col-12 my4' src='/assets/sanctu-compu-logo.svg' alt='medicare' />
+        </div>
       </div>
     );
   }

--- a/src/components/DetailBlock/index.js
+++ b/src/components/DetailBlock/index.js
@@ -10,7 +10,7 @@ class DetailBlock extends Component {
         <img 
           className='col-12 md:col-9 fit-contain my1' 
           src='/assets/image-shirt-detail-1.jpg' 
-          alt='shirt detail image'
+          alt='shirt detail'
         />
         <div 
           className={cx(styles['DetailBlock__image-group-container'], 
@@ -26,9 +26,9 @@ class DetailBlock extends Component {
             </p>
           </div>
           <div className={cx(styles['DetailBlock__image2-container'], 'col-12 md:col-8 my1')}>
-            <img className={cx(styles['DetailBlock__image2'], 'col-12 md:col-9 right fit-contain z0 shadow-light')} src='/assets/image-shirt-detail-2.jpg' alt='shirt detail image' />
+            <img className={cx(styles['DetailBlock__image2'], 'col-12 md:col-9 right fit-contain z0 shadow-light')} src='/assets/image-shirt-detail-2.jpg' alt='shirt detail' />
           </div>
-          <img className={cx(styles['DetailBlock__image3'], 'col-12 md:col-4 z1 w100 h100 fit-contain shadow-light my1')} src='/assets/image-shirt-detail-3.jpg' alt='shirt detail image' />
+          <img className={cx(styles['DetailBlock__image3'], 'col-12 md:col-4 z1 w100 h100 fit-contain shadow-light my1')} src='/assets/image-shirt-detail-3.jpg' alt='shirt detail' />
         </div>
         <div className='w100 relative flex flex-col md:flex-row-reverse md:justify-between md:items-start md:mt4'>
           <div className='col-12 md:col-5'>
@@ -55,7 +55,7 @@ class DetailBlock extends Component {
               </p>
             </div>
           </div>
-          <img className={cx(styles['DetailBlock__image4'], 'col-12 md:col-5 fit-contain shadow-light my1 md:mx2')} src='/assets/image-shirt-detail-4.jpg' alt='shirt detail image' />
+          <img className={cx(styles['DetailBlock__image4'], 'col-12 md:col-5 fit-contain shadow-light my1 md:mx2')} src='/assets/image-shirt-detail-4.jpg' alt='shirt detail' />
         </div>
       </div>
     );

--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -7,7 +7,6 @@
     transform: rotate(-20deg);
     max-height: 100vh;
 
-
     @media ($medium-up) {
       @include aspect-ratio(15, 8);
       transform: rotate(20deg);

--- a/src/components/Hero/index.js
+++ b/src/components/Hero/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import cx from 'classnames';
 import styles from './Hero.scss';
 
-class App extends Component {
+class Hero extends Component {
   render() {
     return (
       <div className={cx(styles['Hero'], 'vw100 vh100 relative flex flex-col items-center')}>
@@ -19,4 +19,4 @@ class App extends Component {
   }
 }
 
-export default App;
+export default Hero;


### PR DESCRIPTION
This does some _very_ light QA on the `DetailsBlock` and `Hero` components.  It also adds the Sanctu Logo SVG to the `DetailsBlock` component on mobile only

**Bottom of `DetailsBlock` on Desktop:**

![image](https://user-images.githubusercontent.com/38109050/48867648-cd532d80-eda4-11e8-865b-a07338db9fd7.png)

**Bottom of `DetailsBlock` on Mobile:**

![image](https://user-images.githubusercontent.com/38109050/48867654-d5ab6880-eda4-11e8-8d0d-87fe7c1c5c60.png)
