### PR TITLE
bind size selector to UI / style UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,13 +16,17 @@ const Sizes = {
   SMALL: "S",
   MEDIUM: "M",
   LARGE: "L",
-  EXTRA_LARGE: "XL"
+  EXTRA_LARGE: "XL",
+  DOUBLE_EXTRA_LARGE: "XXL"
 };
 
 class App extends Component {
   constructor() {
     super(...arguments);
     this.state = { product: null, size: Sizes.MEDIUM }
+
+    this.selectSize = this.selectSize.bind(this);
+
   }
 
   componentWillMount() {
@@ -39,6 +43,7 @@ class App extends Component {
     if (!Object.values(Sizes).includes(size)) {
       throw new Error("Unsupported Size");
     }
+
     this.setState({ size });
   }
 
@@ -67,7 +72,7 @@ class App extends Component {
       <div className='App'>
         <Hero />
         <DetailBlock />
-        <BuyBlock image={get(this.state.product, "images.edges[0].node", {})}/>
+        <BuyBlock clickHandler={this.selectSize}/>
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,11 @@ class App extends Component {
       <div className='App'>
         <Hero />
         <DetailBlock />
-        <BuyBlock sizes={Object.values(Sizes)} clickHandler={this.selectSize}/>
+        <BuyBlock
+          sizes={Object.values(Sizes)}
+          clickHandler={this.selectSize}
+          size={this.state.size}
+        />
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,7 @@ class App extends Component {
       <div className='App'>
         <Hero />
         <DetailBlock />
-        <BuyBlock clickHandler={this.selectSize}/>
+        <BuyBlock sizes={Object.values(Sizes)} clickHandler={this.selectSize}/>
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -70,6 +70,7 @@ class App extends Component {
         <Hero />
         <DetailBlock />
         <BuyBlock
+          image={get(this.state.product, "images.edges[0].node", {})}
           sizes={Object.values(Sizes)}
           clickHandler={this.selectSize}
           size={this.state.size}

--- a/src/App.js
+++ b/src/App.js
@@ -24,9 +24,6 @@ class App extends Component {
   constructor() {
     super(...arguments);
     this.state = { product: null, size: Sizes.MEDIUM }
-
-    this.selectSize = this.selectSize.bind(this);
-
   }
 
   componentWillMount() {
@@ -39,7 +36,7 @@ class App extends Component {
     });
   }
 
-  selectSize(size) {
+  selectSize = size => {
     if (!Object.values(Sizes).includes(size)) {
       throw new Error("Unsupported Size");
     }

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -31,11 +31,6 @@
     &--item {
       border: spacing(0.2) solid transparent;
 
-      // &:last-of-type {
-      //   padding-right: 2rem;
-      //   padding-left: 2rem;
-      // }
-
       &:hover {
         border: spacing(0.2) solid color('light-blue');
         cursor: default;

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -19,16 +19,20 @@
   }
 
   &__list {
+    position: relative;
     font-size: 1.5rem;
     font-weight: 100;
     list-style: none;
-    border: spacing(0.2) solid color('gray');
 
-    li {
-      outline: none;
+    &-border {
+      border: spacing(0.2) solid color('gray');
+    }
+
+    &-item {
+      border: spacing(0.2) solid transparent;
 
       &:hover {
-        outline: spacing(0.2) solid color('light-blue');
+        border: spacing(0.2) solid color('light-blue');
         cursor: default;
       }
     }
@@ -39,6 +43,7 @@
 
     &:hover {
       border-color: color('light-blue');
+
     }
   }
 

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -24,12 +24,17 @@
     font-weight: 100;
     list-style: none;
 
-    &-border {
+    &--border {
       border: spacing(0.2) solid color('gray');
     }
 
-    &-item {
+    &--item {
       border: spacing(0.2) solid transparent;
+
+      // &:last-of-type {
+      //   padding-right: 2rem;
+      //   padding-left: 2rem;
+      // }
 
       &:hover {
         border: spacing(0.2) solid color('light-blue');
@@ -38,17 +43,13 @@
     }
   }
 
-  &__text {
+  &__button {
+    font-size: 1.5rem;
+    font-weight: 100;
     border: spacing(0.2) solid color('gray');
 
     &:hover {
       border-color: color('light-blue');
-
     }
-  }
-
-  &__button {
-    font-size: 1.5rem;
-    font-weight: 100;
   }
 }

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -25,12 +25,21 @@
     border: spacing(0.2) solid color('gray');
 
     li {
-      display: inline-block;
+      outline: none;
+
+      &:hover {
+        outline: spacing(0.2) solid color('light-blue');
+        cursor: default;
+      }
     }
   }
 
   &__text {
     border: spacing(0.2) solid color('gray');
+
+    &:hover {
+      border-color: color('light-blue');
+    }
   }
 
   &__button {

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -37,7 +37,6 @@
         border: spacing(0.2) solid color('light-navy');
         background-color: color('navy');
         color: color('white');
-        cursor: default;
       }
     }
   }

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -32,7 +32,9 @@
       border: spacing(0.2) solid transparent;
 
       &:hover {
-        border: spacing(0.2) solid color('light-blue');
+        border: spacing(0.2) solid color('navy');
+        background-color: color('dark-navy');
+        color: color('white');
         cursor: default;
       }
     }
@@ -44,7 +46,9 @@
     border: spacing(0.2) solid color('gray');
 
     &:hover {
-      border-color: color('light-blue');
+      border-color: color('navy');
+      background-color: color('dark-navy');
+      color: color('white');
     }
   }
 }

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -33,7 +33,7 @@
       width: 20%;
       font-size: 1.2rem;
 
-      &:hover {
+      &:hover, &--selected {
         border: spacing(0.2) solid color('light-navy');
         background-color: color('navy');
         color: color('white');

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -30,6 +30,8 @@
 
     &--item {
       border: spacing(0.2) solid transparent;
+      width: 20%;
+      font-size: 1.2rem;
 
       &:hover {
         border: spacing(0.2) solid color('navy');
@@ -41,7 +43,7 @@
   }
 
   &__button {
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     font-weight: 100;
     border: spacing(0.2) solid color('gray');
 

--- a/src/components/BuyBlock/BuyBlock.scss
+++ b/src/components/BuyBlock/BuyBlock.scss
@@ -34,8 +34,8 @@
       font-size: 1.2rem;
 
       &:hover {
-        border: spacing(0.2) solid color('navy');
-        background-color: color('dark-navy');
+        border: spacing(0.2) solid color('light-navy');
+        background-color: color('navy');
         color: color('white');
         cursor: default;
       }
@@ -48,8 +48,8 @@
     border: spacing(0.2) solid color('gray');
 
     &:hover {
-      border-color: color('navy');
-      background-color: color('dark-navy');
+      border-color: color('light-navy');
+      background-color: color('navy');
       color: color('white');
     }
   }

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -23,13 +23,13 @@ class BuyBlock extends Component {
           <div className="col-12 md:col-6">
             <div className={cx(styles['BuyBlock__box'], 'flex justify-center')}>
               <div className="col-12 md:col-9">
-                <ul className={cx(styles['BuyBlock__list'], 'shadow serif bg-white flex flex-wrap justify-between')}>
+                <ul className={cx(styles['BuyBlock__list'], 'shadow serif bg-white flex flex-wrap justify-center')}>
                   <div className={cx(styles['BuyBlock__list--border'], 'overlay events-none')}></div>
                   {
                     this.props.sizes.map(size => {
                       return (
                         <li
-                          className={cx(styles['BuyBlock__list--item'], 'px2 py1 relative')}
+                          className={cx(styles['BuyBlock__list--item'], 'p1 text-center relative')}
                           onClick={(event) => {
                             event.preventDefault()
                             this.props.clickHandler(size)

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -46,7 +46,7 @@ class BuyBlock extends Component {
           <div className="col-12 md:col-6">
             <div className={cx(styles['BuyBlock__box'], 'flex justify-center')}>
               <div className='col-12 md:col-9'>
-                <div className='shadow flex justify-center'>
+                <div className='shadow bg-white flex justify-center'>
                   <button className={cx(styles['BuyBlock__button'], 'p1 w100')} type="sumbit">
                     <span className="serif">BUY NOW</span>
                   </button>

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -22,19 +22,19 @@ class BuyBlock extends Component {
         >
           <div className={cx(styles['BuyBlock__box'], 'col-12 md:col-6 flex justify-center')}>
             <div className='col-12 md:col-8'>
-              <ul className={cx(styles['BuyBlock__list'], 'shadow serif px2 py1 flex justify-between')}>
-                <li>S</li>
-                <li>M</li>
-                <li>L</li>
-                <li>XL</li>
-                <li>XXL</li>
+              <ul className={cx(styles['BuyBlock__list'], 'shadow serif flex justify-between')}>
+                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XS</li>
+                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>S</li>
+                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>M</li>
+                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>L</li>
+                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XL</li>
               </ul>
             </div>
           </div>
           <div className={cx(styles['BuyBlock__box'], 'col-12 md:col-6 flex justify-center')}>
             <div className='col-12 md:col-8'>
               <div className={cx(styles['BuyBlock__text'], 'shadow flex justify-center')}>
-                <button className={cx(styles['BuyBlock__button'], 'px1 py1 w100')} type="sumbit">
+                <button className={cx(styles['BuyBlock__button'], 'p1 w100')} type="sumbit">
                   <span className="serif">BUY NOW</span>
                 </button>
               </div>

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -29,7 +29,7 @@ class BuyBlock extends Component {
                     this.props.sizes.map(size => {
                       return (
                         <li
-                          className={cx(styles['BuyBlock__list--item'], 'p1 text-center relative')}
+                          className={cx(styles['BuyBlock__list--item'], 'pointer p1 text-center relative')}
                           onClick={(event) => {
                             event.preventDefault()
                             this.props.clickHandler(size)
@@ -47,7 +47,7 @@ class BuyBlock extends Component {
             <div className={cx(styles['BuyBlock__box'], 'flex justify-center')}>
               <div className='col-12 md:col-9'>
                 <div className='shadow bg-white flex justify-center'>
-                  <button className={cx(styles['BuyBlock__button'], 'p1 w100')} type="sumbit">
+                  <button className={cx(styles['BuyBlock__button'], 'pointer p1 w100')} type="sumbit">
                     <span className="serif">BUY NOW</span>
                   </button>
                 </div>

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -22,13 +22,14 @@ class BuyBlock extends Component {
         >
           <div className={cx(styles['BuyBlock__box'], 'col-12 md:col-6 flex justify-center')}>
             <div className='col-12 md:col-8'>
-              <ul className={cx(styles['BuyBlock__list'], 'shadow serif flex justify-between')}>
-                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XS</li>
-                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>S</li>
-                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>M</li>
-                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>L</li>
-                <li className="px2 py1" onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XL</li>
-              </ul>
+              <div className={cx(styles['BuyBlock__list'], 'shadow serif flex justify-between')}>
+                <div className={cx(styles['BuyBlock__list-border'], 'overlay events-none z1')}></div>
+                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XS</div>
+                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>S</div>
+                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>M</div>
+                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>L</div>
+                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XL</div>
+              </div>
             </div>
           </div>
           <div className={cx(styles['BuyBlock__box'], 'col-12 md:col-6 flex justify-center')}>

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -20,24 +20,37 @@ class BuyBlock extends Component {
           className={cx(styles['BuyBlock__container'], 'flex justify-center items-center w100')}
           onSubmit={this.handleFormSubmit}
         >
-          <div className={cx(styles['BuyBlock__box'], 'col-12 md:col-6 flex justify-center')}>
-            <div className='col-12 md:col-8'>
-              <div className={cx(styles['BuyBlock__list'], 'shadow serif flex justify-between')}>
-                <div className={cx(styles['BuyBlock__list-border'], 'overlay events-none z1')}></div>
-                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XS</div>
-                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>S</div>
-                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>M</div>
-                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>L</div>
-                <div className={cx(styles['BuyBlock__list-item'], 'px2 py1 relative z2')} onClick={(event) => this.props.clickHandler(event.currentTarget.textContent)}>XL</div>
+          <div className="col-12 md:col-6">
+            <div className={cx(styles['BuyBlock__box'], 'flex justify-center')}>
+              <div className="col-12 md:col-9">
+                <ul className={cx(styles['BuyBlock__list'], 'shadow serif bg-white flex flex-wrap justify-between')}>
+                  <div className={cx(styles['BuyBlock__list--border'], 'overlay events-none')}></div>
+                  {
+                    this.props.sizes.map(size => {
+                      return (
+                        <li
+                          className={cx(styles['BuyBlock__list--item'], 'px2 py1 relative')}
+                          onClick={(event) => {
+                            event.preventDefault()
+                            this.props.clickHandler(size)
+                          }}>
+                          {size}
+                        </li>
+                      )
+                    })
+                  }
+                </ul>
               </div>
             </div>
           </div>
-          <div className={cx(styles['BuyBlock__box'], 'col-12 md:col-6 flex justify-center')}>
-            <div className='col-12 md:col-8'>
-              <div className={cx(styles['BuyBlock__text'], 'shadow flex justify-center')}>
-                <button className={cx(styles['BuyBlock__button'], 'p1 w100')} type="sumbit">
-                  <span className="serif">BUY NOW</span>
-                </button>
+          <div className="col-12 md:col-6">
+            <div className={cx(styles['BuyBlock__box'], 'flex justify-center')}>
+              <div className='col-12 md:col-9'>
+                <div className='shadow flex justify-center'>
+                  <button className={cx(styles['BuyBlock__button'], 'p1 w100')} type="sumbit">
+                    <span className="serif">BUY NOW</span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/BuyBlock/index.js
+++ b/src/components/BuyBlock/index.js
@@ -29,7 +29,7 @@ class BuyBlock extends Component {
                     this.props.sizes.map(size => {
                       return (
                         <li
-                          className={cx(styles['BuyBlock__list--item'], 'pointer p1 text-center relative')}
+                          className={cx(styles['BuyBlock__list--item'], 'pointer p1 text-center relative', {'BuyBlock__list--item--selected___13RyP': this.props.size === size})}
                           onClick={(event) => {
                             event.preventDefault()
                             this.props.clickHandler(size)

--- a/src/styles/settings/_colors.scss
+++ b/src/styles/settings/_colors.scss
@@ -1,6 +1,8 @@
 $colors: (
   'white': #fff,
   'light-blue': #83d5ff,
+  'navy': #173963,
+  'dark-navy': #17396357,
   'gray': #a7a7a7,
   'black': #222
 );

--- a/src/styles/settings/_colors.scss
+++ b/src/styles/settings/_colors.scss
@@ -2,7 +2,7 @@ $colors: (
   'white': #fff,
   'light-blue': #83d5ff,
   'navy': #173963,
-  'dark-navy': #17396357,
+  'light-navy': #17396357,
   'gray': #a7a7a7,
   'black': #222
 );


### PR DESCRIPTION
This binds the size selector to the UI so that when a size is selected, the state is updated with the selected size.  Each size has a blue border on hover.  The BUY NOW button also has a blue border on hover.  

The hover states gave Conor and I some trouble during development.  My eventual solution has resulted in the size selector having to break onto two lines on small screen sizes.  Screen shot attached: 

![image](https://user-images.githubusercontent.com/38109050/49118117-34735500-f271-11e8-9f46-550613b6788a.png)
